### PR TITLE
remove cohens-kappa

### DIFF
--- a/LSTM_model_offensive (1).ipynb
+++ b/LSTM_model_offensive (1).ipynb
@@ -671,9 +671,6 @@
     "f1 = f1_score(rounded_labels, rounded_predictions,average='micro')\n",
     "print('F1 score: %f' % f1)\n",
     " \n",
-    "# kappa\n",
-    "kappa = cohen_kappa_score(rounded_labels, rounded_predictions)\n",
-    "print('Cohens kappa: %f' % kappa)"
    ]
   },
   {


### PR DESCRIPTION
remove cohens-kappa  as it is for an inter-annotator agreement and it is not of any use